### PR TITLE
Add Aspire host project references

### DIFF
--- a/src/AppHost/Program.cs
+++ b/src/AppHost/Program.cs
@@ -1,10 +1,13 @@
 using Aspire.Hosting;
+using Aspire.Hosting.ApplicationModel;
 
 var builder = DistributedApplication.CreateBuilder(args);
 
-var api = builder.AddProject("webapi", "../WebApi/WebApi.csproj");
+var api = builder.AddProject<Projects.WebApi>("webapi");
 
-builder.AddProject("unoapp", "../UnoApp/UnoApp/UnoApp.csproj")
+builder.AddProject<Projects.UnoApp>("unoapp")
        .WithReference(api);
+
+builder.AddDashboard();
 
 builder.Build().Run();

--- a/src/AppHost/Projects.cs
+++ b/src/AppHost/Projects.cs
@@ -1,0 +1,14 @@
+using Aspire.Hosting.ApplicationModel;
+
+internal static partial class Projects
+{
+    internal sealed class WebApi : IProjectMetadata
+    {
+        public string ProjectPath => "../WebApi/WebApi.csproj";
+    }
+
+    internal sealed class UnoApp : IProjectMetadata
+    {
+        public string ProjectPath => "../UnoApp/UnoApp/UnoApp.csproj";
+    }
+}


### PR DESCRIPTION
## Summary
- integrate .NET Aspire typed project references
- enable Aspire dashboard in the app host

## Testing
- `dotnet build src/AppHost/AppHost.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e915c88f4832ca26e6b5ef0d66d74