### PR TITLE
Refactor imports for Directory.Packages.props

### DIFF
--- a/src/UnoApp/Directory.Build.targets
+++ b/src/UnoApp/Directory.Build.targets
@@ -1,15 +1,9 @@
 <Project>
-    <Import Project="Directory.Packages.props" Condition="exists('Directory.Packages.props')" />
-    <Import Project="..\Directory.Packages.props" Condition="exists('..\Directory.Packages.props')" />
-    <Import Project="..\..\Directory.Packages.props" Condition="exists('..\..\Directory.Packages.props')" />
-    <Import Project="..\..\..\Directory.Packages.props" Condition="exists('..\..\..\Directory.Packages.props')" />
-    <Import Project="..\..\..\..\Directory.Packages.props" Condition="exists('..\..\..\..\Directory.Packages.props')" />
-    <Import Project="..\..\..\..\..\Directory.Packages.props" Condition="exists('..\..\..\..\..\Directory.Packages.props')" />
-    <Import Project="..\..\..\..\..\..\Directory.Packages.props" Condition="exists('..\..\..\..\..\..\Directory.Packages.props')" />
-    <Import Project="..\..\..\..\..\..\..\Directory.Packages.props" Condition="exists('..\..\..\..\..\..\..\Directory.Packages.props')" />
-    <Import Project="..\..\..\..\..\..\..\..\Directory.Packages.props" Condition="exists('..\..\..\..\..\..\..\..\Directory.Packages.props')" />
-    <Import Project="..\..\..\..\..\..\..\..\..\Directory.Packages.props" Condition="exists('..\..\..\..\..\..\..\..\..\Directory.Packages.props')" />
-    <ItemGroup>
+  <PropertyGroup>
+    <_DirectoryPackagesPropsPath>$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'Directory.Packages.props'))\Directory.Packages.props</_DirectoryPackagesPropsPath>
+  </PropertyGroup>
+  <Import Project="$(_DirectoryPackagesPropsPath)" Condition="Exists('$(_DirectoryPackagesPropsPath)')" />
+  <ItemGroup>
 
-    </ItemGroup>
+  </ItemGroup>
 </Project>

--- a/src/UnoApp/Directory.Packages.props
+++ b/src/UnoApp/Directory.Packages.props
@@ -1,15 +1,9 @@
 <Project ToolsVersion="15.0">
 
-  <Import Project="Directory.Packages.props" Condition="exists('Directory.Packages.props')" />
-  <Import Project="..\Directory.Packages.props" Condition="exists('..\Directory.Packages.props')" />
-  <Import Project="..\..\Directory.Packages.props" Condition="exists('..\..\Directory.Packages.props')" />
-  <Import Project="..\..\..\Directory.Packages.props" Condition="exists('..\..\..\Directory.Packages.props')" />
-  <Import Project="..\..\..\..\Directory.Packages.props" Condition="exists('..\..\..\..\Directory.Packages.props')" />
-  <Import Project="..\..\..\..\..\Directory.Packages.props" Condition="exists('..\..\..\..\..\Directory.Packages.props')" />
-  <Import Project="..\..\..\..\..\..\Directory.Packages.props" Condition="exists('..\..\..\..\..\..\Directory.Packages.props')" />
-  <Import Project="..\..\..\..\..\..\..\Directory.Packages.props" Condition="exists('..\..\..\..\..\..\..\Directory.Packages.props')" />
-  <Import Project="..\..\..\..\..\..\..\..\Directory.Packages.props" Condition="exists('..\..\..\..\..\..\..\..\Directory.Packages.props')" />
-  <Import Project="..\..\..\..\..\..\..\..\..\Directory.Packages.props" Condition="exists('..\..\..\..\..\..\..\..\..\Directory.Packages.props')" />
+  <PropertyGroup>
+    <_DirectoryPackagesPropsPath>$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'Directory.Packages.props'))\Directory.Packages.props</_DirectoryPackagesPropsPath>
+  </PropertyGroup>
+  <Import Project="$(_DirectoryPackagesPropsPath)" Condition="Exists('$(_DirectoryPackagesPropsPath)')" />
   <!--
     To update the version of Uno, you should instead update the Sdk version in the global.json file.
 


### PR DESCRIPTION
## Summary
- simplify locating `Directory.Packages.props` by using `GetDirectoryNameOfFileAbove`
- drop numerous hard-coded relative imports

## Testing
- `dotnet build src/UnoApp/UnoApp.sln -v q` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e9d5d943c832c88df9fd656a9e34f