### PR TITLE
Add in-memory database

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -17,5 +17,7 @@
     <PackageVersion Include="Microsoft.Kiota.Cli.Commons" Version="1.1.2" />
     <PackageVersion Include="Aspire.Hosting" Version="9.0.0-preview.4" />
     <PackageVersion Include="Aspire.Dashboard" Version="9.0.0-preview.4" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="8.0.6" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.6" />
   </ItemGroup>
 </Project>

--- a/src/WebApi/Data/AppDbContext.cs
+++ b/src/WebApi/Data/AppDbContext.cs
@@ -1,0 +1,15 @@
+using Microsoft.EntityFrameworkCore;
+using SharedModels.Dtos.Contacts;
+
+namespace WebApi.Data
+{
+    public class AppDbContext : DbContext
+    {
+        public AppDbContext(DbContextOptions<AppDbContext> options)
+            : base(options)
+        {
+        }
+
+        public DbSet<ContactDto> Contacts => Set<ContactDto>();
+    }
+}

--- a/src/WebApi/Program.cs
+++ b/src/WebApi/Program.cs
@@ -1,4 +1,6 @@
 using Microsoft.AspNetCore.Builder;
+using Microsoft.EntityFrameworkCore;
+using WebApi.Data;
 
 namespace WebApi
 {
@@ -9,6 +11,8 @@ namespace WebApi
             var builder = WebApplication.CreateBuilder(args);
             builder.Services.AddShinyMediator(x => x.AddGeneratedEndpoints());
             // Add services to the container.
+            builder.Services.AddDbContext<AppDbContext>(options =>
+                options.UseInMemoryDatabase("SalesDb"));
             builder.Services.AddControllers();
             // Learn more about configuring OpenAPI at https://aka.ms/aspnet/openapi
             builder.Services.AddOpenApi();

--- a/src/WebApi/WebApi.csproj
+++ b/src/WebApi/WebApi.csproj
@@ -11,6 +11,7 @@
     <PackageReference Include="Shiny.Mediator.AspNet" />
     <PackageReference Include="Swashbuckle.AspNetCore" />
     <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
- add Entity Framework Core packages
- register DbContext for in-memory use
- define AppDbContext using existing `ContactDto`
- remove redundant `Contact` entity

## Testing
- `dotnet build src/WebApi/WebApi.csproj -c Release` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685eafbf7abc832c8d884e1bb61f4bab