### PR TITLE
Add API description support

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -19,5 +19,6 @@
     <PackageVersion Include="Aspire.Dashboard" Version="9.0.0-preview.4" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="8.0.6" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.6" />
+    <PackageVersion Include="Microsoft.Extensions.ApiDescription.Server" Version="9.0.6" />
   </ItemGroup>
 </Project>

--- a/src/WebApi/Program.cs
+++ b/src/WebApi/Program.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Builder;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.ApiDescription.Server;
 using WebApi.Data;
 
 namespace WebApi
@@ -16,6 +17,7 @@ namespace WebApi
             builder.Services.AddControllers();
             // Learn more about configuring OpenAPI at https://aka.ms/aspnet/openapi
             builder.Services.AddOpenApi();
+            builder.Services.AddApiDescription();
             builder.Services.AddEndpointsApiExplorer();
             builder.Services.AddSwaggerGen();
 
@@ -25,6 +27,7 @@ namespace WebApi
             if (app.Environment.IsDevelopment())
             {
                 app.MapOpenApi();
+                app.MapApiDescription();
                 app.UseSwagger();
                 app.UseSwaggerUI();
             }

--- a/src/WebApi/WebApi.csproj
+++ b/src/WebApi/WebApi.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" />
+    <PackageReference Include="Microsoft.Extensions.ApiDescription.Server" />
     <PackageReference Include="Shiny.Mediator.AspNet" />
     <PackageReference Include="Swashbuckle.AspNetCore" />
     <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" />


### PR DESCRIPTION
## Summary
- add Microsoft.Extensions.ApiDescription.Server package version
- register API description services and endpoints in WebApi

## Testing
- `dotnet build src/WebApi/WebApi.csproj -c Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ebd874840832c9623f5e8eef18943