### PR TITLE
Add JWT Auth button in Scalar and document OpenAPI generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,11 @@
+# Orderlyze Sales API
+
+This repository contains a sample ASP.NET Core project with automatic OpenAPI generation.
+
+## OpenAPI Generation
+
+The `Microsoft.Extensions.ApiDescription.Server` package automatically creates an OpenAPI document every time the project is built. When running in development, the OpenAPI spec is available through Swagger UI and Scalar.
+
+## Scalar UI Authentication
+
+Scalar is configured to display an `Authorize` button for JWT bearer tokens. Supply a valid token to authenticate calls directly from the documentation UI.

--- a/src/WebApi/Program.cs
+++ b/src/WebApi/Program.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.OpenApi.Models;
 using Scalar.AspNetCore;
 using WebApi.Data;
 
@@ -20,7 +21,27 @@ namespace WebApi
             // Learn more about configuring OpenAPI at https://aka.ms/aspnet/openapi
             builder.Services.AddOpenApi();
             builder.Services.AddEndpointsApiExplorer();
-            builder.Services.AddSwaggerGen();
+            builder.Services.AddSwaggerGen(options =>
+            {
+                var securityScheme = new OpenApiSecurityScheme
+                {
+                    Name = "Authorization",
+                    Type = SecuritySchemeType.Http,
+                    Scheme = "bearer",
+                    BearerFormat = "JWT",
+                    In = ParameterLocation.Header,
+                    Description = "JWT Authorization header using the Bearer scheme."
+                };
+
+                options.AddSecurityDefinition("Bearer", securityScheme);
+
+                var requirement = new OpenApiSecurityRequirement
+                {
+                    { securityScheme, Array.Empty<string>() }
+                };
+
+                options.AddSecurityRequirement(requirement);
+            });
 
             builder.Services
                 .AddIdentityCore<AppUser>()


### PR DESCRIPTION
## Summary
- add JWT security scheme so Swagger/Scalar UI shows the **Authorize** button
- document automatic OpenAPI generation and authentication in a new README

## Testing
- `dotnet build src/WebApi/WebApi.csproj -nologo` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f05058514832cbd0df1d403356620