### PR TITLE
Add codex agent guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,21 @@
+# Codex Instructions
+
+## General Guidelines
+- Use C# 12 (.NET 9) features.
+- Indent C# code with four spaces.
+- End every file with a newline.
+- Prefer file-scoped namespaces when practical.
+
+## Shiny Mediator Usage
+- The API and UnoApp are built around the **Shiny.Mediator** pattern.
+- When adding or updating endpoints or features, create request and handler classes and decorate them with the appropriate `MediatorHttp*` attributes.
+- API requests belong under `src/WebApi/Mediator/Requests` and handlers under `src/WebApi/Mediator/Handlers`.
+- UnoApp features should access the API using generated mediator clients rather than raw HTTP calls.
+
+## Testing
+- Run `dotnet build src/WebApi/WebApi.csproj` and `dotnet build src/UnoApp/UnoApp.sln` before committing.
+- If these commands fail because the environment lacks the .NET SDK, mention this limitation in the PR.
+
+## Pull Requests
+- Summarize how changes follow the Shiny Mediator pattern.
+- Report the result of the build commands.

--- a/src/UnoApp/AGENTS.md
+++ b/src/UnoApp/AGENTS.md
@@ -1,0 +1,7 @@
+# UnoApp Guidelines
+
+UnoApp communicates with the API through Shiny Mediator.
+
+- Prefer generated mediator clients over raw `HttpClient` or Refit when calling the API.
+- View models should send mediator requests and process the responses asynchronously.
+- Keep view models small and follow the MVUX approach provided by Uno Platform.

--- a/src/WebApi/AGENTS.md
+++ b/src/WebApi/AGENTS.md
@@ -1,0 +1,8 @@
+# WebApi Guidelines
+
+All endpoints must use the Shiny Mediator pattern.
+
+- Request classes implement `IRequest<T>` and live in `Mediator/Requests`.
+- Handlers implement `IRequestHandler<TRequest, TResponse>` and live in `Mediator/Handlers`.
+- Group related handlers using `[MediatorHttpGroup]` and expose actions with `[MediatorHttpGet]`, `[MediatorHttpPost]`, etc.
+- Register mediator endpoints in `Program.cs` using `AddShinyMediator` and `MapGeneratedMediatorEndpoints`.


### PR DESCRIPTION
## Summary
- add AGENTS instructions for repository root
- add WebApi guidelines that require Shiny Mediator endpoints
- add UnoApp guidelines that encourage using Mediator clients

## Testing
- `dotnet build src/WebApi/WebApi.csproj` *(fails: dotnet not found)*
- `dotnet build src/UnoApp/UnoApp.sln` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f9b400c84832cad95adae62b59765