### PR TITLE
Move Wix API options to configuration

### DIFF
--- a/src/External/WixApi/ModuleInitializer.cs
+++ b/src/External/WixApi/ModuleInitializer.cs
@@ -2,22 +2,24 @@ namespace WixApi;
 
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Options;
 using WixApi.Repositories;
 
 public static class ModuleInitializer
 {
     public static IServiceCollection AddWixApi(this IServiceCollection services, IConfiguration configuration)
     {
-        services.Configure<WixApiOptions>(configuration.GetSection("WixApi"));
+        var wixApiSection = configuration.GetSection("WixApi");
+        var baseUrl = wixApiSection["BaseUrl"];
+        var apiKey = wixApiSection["ApiKey"];
+        var accountId = wixApiSection["AccountId"];
+        var siteId = wixApiSection["SiteId"];
 
-        services.AddHttpClient("WixApiClient", (sp, client) =>
+        services.AddHttpClient("WixApiClient", client =>
         {
-            var options = sp.GetRequiredService<IOptions<WixApiOptions>>().Value;
-            client.BaseAddress = new Uri(options.BaseUrl);
-            client.DefaultRequestHeaders.Add("Authorization", options.ApiKey);
-            client.DefaultRequestHeaders.Add("wix-account-id", options.AccountId);
-            client.DefaultRequestHeaders.Add("wix-site-id", options.SiteId);
+            client.BaseAddress = new Uri(baseUrl);
+            client.DefaultRequestHeaders.Add("Authorization", apiKey);
+            client.DefaultRequestHeaders.Add("wix-account-id", accountId);
+            client.DefaultRequestHeaders.Add("wix-site-id", siteId);
         });
 
         return services

--- a/src/External/WixApi/Repositories/BaseWixRepository.cs
+++ b/src/External/WixApi/Repositories/BaseWixRepository.cs
@@ -1,5 +1,5 @@
 ﻿using Refit;
-using Microsoft.Extensions.Options;
+
 
 namespace WixApi.Repositories
 {
@@ -7,14 +7,11 @@ namespace WixApi.Repositories
     {
         protected readonly TApi RepositoryApi;
         private readonly IHttpClientFactory _clientFactory;
-        private readonly WixApiOptions _options;
 
-        protected BaseWixRepository(IHttpClientFactory clientFactory, IOptions<WixApiOptions> options)
+        protected BaseWixRepository(IHttpClientFactory clientFactory)
         {
             _clientFactory = clientFactory;
-            _options = options.Value;
             var client = _clientFactory.CreateClient("WixApiClient");
-            client.BaseAddress = new Uri(_options.BaseUrl);
             RepositoryApi = RestService.For<TApi>(client, BuildApiSettings());
         }
 
@@ -35,7 +32,7 @@ namespace WixApi.Repositories
         /// <returns>Current access token</returns>
         protected virtual Task<string> GetAuthorizationHeaderValueAsync(HttpRequestMessage message, CancellationToken token)
         {
-            return Task.FromResult("Authorization: " + _options.ApiKey);
+            return Task.FromResult(string.Empty);
         }
 
         protected virtual async Task<T> TryRequest<T>(Func<Task<T>> func, T defaultValue = default(T))

--- a/src/External/WixApi/Repositories/ConversationsRepository.cs
+++ b/src/External/WixApi/Repositories/ConversationsRepository.cs
@@ -1,12 +1,11 @@
 ﻿using WixApi.Apis;
-using Microsoft.Extensions.Options;
 
 namespace WixApi.Repositories
 {
     public class ConversationsRepository : BaseWixRepository<IConversationApi>, IConversationsRepository
     {
-        public ConversationsRepository(IHttpClientFactory clientFactory, IOptions<WixApiOptions> options)
-            : base(clientFactory, options)
+        public ConversationsRepository(IHttpClientFactory clientFactory)
+            : base(clientFactory)
         {
         }
         public async Task<string> GetConversations()

--- a/src/External/WixApi/Repositories/WixContactsRepository.cs
+++ b/src/External/WixApi/Repositories/WixContactsRepository.cs
@@ -1,13 +1,12 @@
 ﻿using WixApi.Apis;
 using WixApi.Models;
-using Microsoft.Extensions.Options;
 
 namespace WixApi.Repositories
 {
     public class WixContactsRepository : BaseWixRepository<IWixContactsApi>, IWixContactsRepository
     {
-        public WixContactsRepository(IHttpClientFactory clientFactory, IOptions<WixApiOptions> options)
-            : base(clientFactory, options) { }
+        public WixContactsRepository(IHttpClientFactory clientFactory)
+            : base(clientFactory) { }
 
         public async Task<List<WixContact>> GetContactsAsync(int limit = 20)
         {

--- a/src/External/WixApi/WixApiOptions.cs
+++ b/src/External/WixApi/WixApiOptions.cs
@@ -1,9 +1,0 @@
-namespace WixApi;
-
-public class WixApiOptions
-{
-    public string BaseUrl { get; set; } = "https://www.wixapis.com";
-    public string AccountId { get; set; } = "website3583";
-    public string SiteId { get; set; } = "c069009d-e1e7-40c2-82aa-c906e0cdad8c";
-    public string ApiKey { get; set; } = "xx";
-}

--- a/src/WebApi/appsettings.Development.json
+++ b/src/WebApi/appsettings.Development.json
@@ -9,5 +9,11 @@
     "Key": "SuperSecretKey12345",
     "Issuer": "OrderlyzeApi",
     "Audience": "OrderlyzeApiUsers"
+  },
+  "WixApi": {
+    "BaseUrl": "https://www.wixapis.com",
+    "AccountId": "website3583",
+    "SiteId": "c069009d-e1e7-40c2-82aa-c906e0cdad8c",
+    "ApiKey": "xx"
   }
 }

--- a/src/WebApi/appsettings.json
+++ b/src/WebApi/appsettings.json
@@ -11,5 +11,11 @@
     "Key": "SuperSecretKey12345",
     "Issuer": "OrderlyzeApi",
     "Audience": "OrderlyzeApiUsers"
+  },
+  "WixApi": {
+    "BaseUrl": "https://www.wixapis.com",
+    "AccountId": "website3583",
+    "SiteId": "c069009d-e1e7-40c2-82aa-c906e0cdad8c",
+    "ApiKey": "xx"
   }
 }


### PR DESCRIPTION
## Summary
- move WixApi configuration values into `appsettings.json`
- remove `WixApiOptions` type and simplify repositories
- configure `WixApiClient` using values from configuration

## Testing
- `dotnet build src/UnoApp/UnoApp.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fa828fab4832cb06c452c64ce0566