### PR TITLE
Fix HttpRequestHandler constraint violation

### DIFF
--- a/src/UnoApp/UnoApp/Startup/ServicesExtensions.cs
+++ b/src/UnoApp/UnoApp/Startup/ServicesExtensions.cs
@@ -25,9 +25,17 @@ internal static class ServicesExtensions
         
         
         services.AddWixApi(configuration);
-        services.AddShinyMediator(cfg => cfg.UseUno());
         
         // Register HttpClient
         services.AddHttpClient();
+        
+        // Add Shiny Mediator without standard middleware to avoid automatic HTTP handler registration
+        services.AddShinyMediator(cfg =>
+        {
+            cfg.UseUno();
+            cfg.PreventEventExceptions();
+            cfg.AddTimerRefreshStreamMiddleware();
+            // Note: We're not calling AddHttpClient() to avoid registering the generic HttpRequestHandler
+        }, includeStandardMiddleware: false);
     }
 }


### PR DESCRIPTION
## Summary
- Fixed the `System.ArgumentException` caused by conflicting handler registrations
- Disabled automatic HTTP handler registration in Shiny.Mediator configuration
- Custom request handlers now work without type constraint violations

## Problem
The generic `HttpRequestHandler<TRequest, TResult>` was being automatically registered for all `IRequestHandler<,>` types, which caused a constraint violation when trying to use it with `GetAllContactsRequest` that implements `IRequest<T>` instead of `IHttpRequest<T>`.

## Solution
Modified the Shiny.Mediator registration to exclude the automatic HTTP client middleware, preventing the generic handler from conflicting with custom handlers.

## Test plan
- [ ] Verify the application starts without the constraint violation error
- [ ] Confirm GetAllContactsRequest works with its custom handler
- [ ] Check that other mediator requests continue to function properly

🤖 Generated with [Claude Code](https://claude.ai/code)