### PR TITLE
docs: Add Shiny.Mediator package management info

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,7 @@
 
 ## Shiny Mediator Usage
 - The API and UnoApp are built around the **Shiny.Mediator** pattern.
+- Shiny.Mediator uses central package management with package versions defined in `Directory.packages.props` inside the mediator src directory.
 - When adding or updating endpoints or features, create request and handler classes and decorate them with the appropriate `MediatorHttp*` attributes.
 - API requests belong under `src/WebApi/Mediator/Requests` and handlers under `src/WebApi/Mediator/Handlers`.
 - UnoApp features should access the API using generated mediator clients rather than raw HTTP calls.


### PR DESCRIPTION
## Summary
- Added documentation about Shiny.Mediator's central package management
- Specified that package versions are defined in `Directory.packages.props` inside the mediator src directory

## Test plan
- [x] Documentation update only - no code changes
- [x] Verified AGENTS.md formatting is preserved

🤖 Generated with [Claude Code](https://claude.ai/code)