### PR TITLE
Fix WebAssembly blank page issue

### DIFF
--- a/src/UnoApp/UnoApp/Presentation/Shell.xaml
+++ b/src/UnoApp/UnoApp/Presentation/Shell.xaml
@@ -8,29 +8,12 @@
       mc:Ignorable="d"
       d:DesignHeight="300"
       d:DesignWidth="400">
-  <Border Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
-    <utu:ExtendedSplashScreen x:Name="Splash"
-                HorizontalAlignment="Stretch"
-                VerticalAlignment="Stretch"
-                HorizontalContentAlignment="Stretch"
-                VerticalContentAlignment="Stretch">
-      <utu:ExtendedSplashScreen.LoadingContentTemplate>
-        <DataTemplate>
-          <Grid>
-            <Grid.RowDefinitions>
-              <RowDefinition Height="2*" />
-              <RowDefinition />
-            </Grid.RowDefinitions>
-
-            <ProgressRing IsActive="True"
-                  Grid.Row="1"
-                  VerticalAlignment="Center"
-                  HorizontalAlignment="Center"
-                  Height="100"
-                  Width="100" />
-          </Grid>
-        </DataTemplate>
-      </utu:ExtendedSplashScreen.LoadingContentTemplate>
-    </utu:ExtendedSplashScreen>
-  </Border>
+  <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+    <!-- Simple ContentControl that works on all platforms including WebAssembly -->
+    <ContentControl x:Name="MainContent"
+                    HorizontalAlignment="Stretch"
+                    VerticalAlignment="Stretch"
+                    HorizontalContentAlignment="Stretch"
+                    VerticalContentAlignment="Stretch" />
+  </Grid>
 </UserControl>

--- a/src/UnoApp/UnoApp/Presentation/Shell.xaml.cs
+++ b/src/UnoApp/UnoApp/Presentation/Shell.xaml.cs
@@ -6,5 +6,5 @@ public sealed partial class Shell : UserControl, IContentControlProvider
     {
         this.InitializeComponent();
     }
-    public ContentControl ContentControl => Splash;
+    public ContentControl ContentControl => MainContent;
 }


### PR DESCRIPTION
## Summary
- Fixed the blank page issue that was occurring when running the UnoApp in WebAssembly mode
- Replaced ExtendedSplashScreen with a simple ContentControl for better platform compatibility

## Changes
- Modified `Shell.xaml` to use ContentControl instead of ExtendedSplashScreen
- Updated `Shell.xaml.cs` to reference MainContent instead of Splash

## Problem
The ExtendedSplashScreen component was not properly transitioning to show the main content in WebAssembly, causing the app to display a blank page indefinitely.

## Solution
Using a simple ContentControl ensures immediate content display without waiting for splash screen conditions, which resolves the blank page issue on WebAssembly platform.

## Test plan
- [x] Build and run the WebAssembly version
- [x] Verify that the MainPage content is displayed properly
- [x] Ensure no regression on Desktop platform

🤖 Generated with [Claude Code](https://claude.ai/code)