### PR TITLE
Add operationIds to Identity API endpoints

### DIFF
--- a/src/WebApi/Helpers/Authentication/IdentityOperationIdTransformer.cs
+++ b/src/WebApi/Helpers/Authentication/IdentityOperationIdTransformer.cs
@@ -1,0 +1,47 @@
+using Microsoft.AspNetCore.OpenApi;
+using Microsoft.OpenApi.Models;
+
+namespace WebApi.Helpers.Authentication;
+
+public class IdentityOperationIdTransformer : IOpenApiDocumentTransformer
+{
+    public Task TransformAsync(OpenApiDocument document, OpenApiDocumentTransformerContext context, CancellationToken cancellationToken)
+    {
+        foreach (var path in document.Paths)
+        {
+            foreach (var operation in path.Value.Operations)
+            {
+                if (operation.Value.OperationId == null)
+                {
+                    // Generate operationId based on path and HTTP method
+                    var operationId = GenerateOperationId(path.Key, operation.Key);
+                    if (!string.IsNullOrEmpty(operationId))
+                    {
+                        operation.Value.OperationId = operationId;
+                    }
+                }
+            }
+        }
+
+        return Task.CompletedTask;
+    }
+
+    private string? GenerateOperationId(string path, OperationType method)
+    {
+        // Map Identity endpoints to meaningful operation IDs
+        return (path.ToLower(), method) switch
+        {
+            ("/register", OperationType.Post) => "Register",
+            ("/login", OperationType.Post) => "Login",
+            ("/refresh", OperationType.Post) => "Refresh",
+            ("/confirmemail", OperationType.Get) => "ConfirmEmail",
+            ("/resendconfirmationemail", OperationType.Post) => "ResendConfirmationEmail",
+            ("/forgotpassword", OperationType.Post) => "ForgotPassword",
+            ("/resetpassword", OperationType.Post) => "ResetPassword",
+            ("/manage/2fa", OperationType.Post) => "ManageTwoFactor",
+            ("/manage/info", OperationType.Get) => "GetManageInfo",
+            ("/manage/info", OperationType.Post) => "PostManageInfo",
+            _ => null
+        };
+    }
+}

--- a/src/WebApi/Program.cs
+++ b/src/WebApi/Program.cs
@@ -26,6 +26,7 @@ namespace WebApi
                 options =>
                 {
                     options.AddDocumentTransformer<BearerSecuritySchemeTransformer>();
+                    options.AddDocumentTransformer<IdentityOperationIdTransformer>();
                 }
             );
 

--- a/src/WebApi/WebApi.json
+++ b/src/WebApi/WebApi.json
@@ -10,6 +10,7 @@
         "tags": [
           "WebApi"
         ],
+        "operationId": "Register",
         "requestBody": {
           "content": {
             "application/json": {
@@ -42,6 +43,7 @@
         "tags": [
           "WebApi"
         ],
+        "operationId": "Login",
         "parameters": [
           {
             "name": "useCookies",
@@ -87,6 +89,7 @@
         "tags": [
           "WebApi"
         ],
+        "operationId": "Refresh",
         "requestBody": {
           "content": {
             "application/json": {
@@ -154,6 +157,7 @@
         "tags": [
           "WebApi"
         ],
+        "operationId": "ResendConfirmationEmail",
         "requestBody": {
           "content": {
             "application/json": {
@@ -176,6 +180,7 @@
         "tags": [
           "WebApi"
         ],
+        "operationId": "ForgotPassword",
         "requestBody": {
           "content": {
             "application/json": {
@@ -208,6 +213,7 @@
         "tags": [
           "WebApi"
         ],
+        "operationId": "ResetPassword",
         "requestBody": {
           "content": {
             "application/json": {
@@ -240,6 +246,7 @@
         "tags": [
           "WebApi"
         ],
+        "operationId": "ManageTwoFactor",
         "requestBody": {
           "content": {
             "application/json": {
@@ -282,6 +289,7 @@
         "tags": [
           "WebApi"
         ],
+        "operationId": "GetManageInfo",
         "responses": {
           "200": {
             "description": "OK",
@@ -312,6 +320,7 @@
         "tags": [
           "WebApi"
         ],
+        "operationId": "PostManageInfo",
         "requestBody": {
           "content": {
             "application/json": {


### PR DESCRIPTION
## Summary
- Add missing operationIds to all Microsoft Identity API endpoints
- Enables Shiny.Mediator to generate HttpRequest classes for authentication endpoints
- Fixes the issue where Login, Register, and other Identity endpoints were not generating client code

## Problem
Shiny.Mediator only generates HttpRequest classes for endpoints that have an `operationId` in the OpenAPI specification. The Microsoft Identity API endpoints (`/login`, `/register`, `/refresh`, etc.) didn't have operationIds, so no client code was generated for them.

## Solution
Created an `IdentityOperationIdTransformer` that adds appropriate operationIds to all Identity endpoints:
- `/register` → `Register`
- `/login` → `Login`
- `/refresh` → `Refresh`
- `/confirmEmail` → `ConfirmEmail`
- `/resendConfirmationEmail` → `ResendConfirmationEmail`
- `/forgotPassword` → `ForgotPassword`
- `/resetPassword` → `ResetPassword`
- `/manage/2fa` → `ManageTwoFactor`
- `/manage/info` GET → `GetManageInfo`
- `/manage/info` POST → `PostManageInfo`

## Changes
- **`IdentityOperationIdTransformer.cs`**: New OpenAPI document transformer that adds operationIds
- **`Program.cs`**: Register the new transformer
- **`WebApi.json`**: Regenerated with operationIds

## Test plan
- [x] Build project successfully
- [x] Verify WebApi.json contains operationIds for all Identity endpoints
- [ ] Rebuild UnoApp project to generate HttpRequest classes
- [ ] Verify LoginHttpRequest, RegisterHttpRequest, etc. are generated

🤖 Generated with [Claude Code](https://claude.ai/code)