### PR TITLE
Fix: Navigation zwischen Login und Register Seiten

### DIFF
--- a/src/UnoApp/UnoApp/Presentation/Pages/Login/LoginPageViewModel.cs
+++ b/src/UnoApp/UnoApp/Presentation/Pages/Login/LoginPageViewModel.cs
@@ -1,6 +1,7 @@
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Microsoft.Extensions.Logging;
+using Shiny.Extensions.DependencyInjection;
 using UnoApp.Navigation;
 using UnoApp.Presentation.Common;
 using UnoApp.Presentation.Pages.Main;
@@ -11,6 +12,7 @@ using ICommand = System.Windows.Input.ICommand;
 
 namespace UnoApp.Presentation.Pages.Login;
 
+[Service(ServiceLifetime.Transient)]
 internal partial class LoginPageViewModel : BasePageViewModel
 {
     private readonly Authentication.IAuthenticationService _authService;

--- a/src/UnoApp/UnoApp/Presentation/Pages/Register/RegisterPageViewModel.cs
+++ b/src/UnoApp/UnoApp/Presentation/Pages/Register/RegisterPageViewModel.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Microsoft.Extensions.Logging;
+using Shiny.Extensions.DependencyInjection;
 using Shiny.Mediator;
 using UnoApp.ApiClient;
 using UnoApp.Presentation.Pages.Login;
@@ -11,6 +12,7 @@ using Authentication = UnoApp.Services.Authentication;
 
 namespace UnoApp.Presentation.Pages.Register;
 
+[Service(ServiceLifetime.Transient)]
 public partial class RegisterPageViewModel : ObservableObject
 {
     private readonly IMediator _mediator;


### PR DESCRIPTION
## Summary
- Service-Attribute für LoginPageViewModel und RegisterPageViewModel hinzugefügt
- Beide ViewModels werden jetzt korrekt im DI-Container registriert  
- Navigation funktioniert wieder in beide Richtungen

## Problem
Die Navigation von der Register-Seite zurück zur Login-Seite funktionierte nicht, wenn der "Zur Anmeldung" Button gedrückt wurde. Dies lag daran, dass die ViewModels nicht im DI-Container registriert waren.

## Lösung
Durch das Hinzufügen des `[Service(ServiceLifetime.Transient)]` Attributes zu beiden ViewModels werden diese automatisch durch den Source Generator von Shiny.Extensions.DependencyInjection registriert.

## Test Plan
- [ ] Uno App starten
- [ ] Zur Login-Seite navigieren
- [ ] Auf "Registrieren" klicken → Register-Seite sollte erscheinen
- [ ] Auf "Zur Anmeldung" klicken → Login-Seite sollte wieder erscheinen
- [ ] Navigation in beide Richtungen mehrmals testen

🤖 Generated with [Claude Code](https://claude.ai/code)