### PR TITLE
Fix navigation visibility issue between Contacts and WixContacts pages

### DIFF
--- a/src/UnoApp/UnoApp/Presentation/Pages/Main/MainPage.xaml
+++ b/src/UnoApp/UnoApp/Presentation/Pages/Main/MainPage.xaml
@@ -30,8 +30,12 @@
                 <Grid uen:Region.Name="One" />
                 <Grid uen:Region.Name="Two" />
                 <Grid uen:Region.Name="Three" />
-                <ContentControl uen:Region.Name="{x:Bind constants:PageNames.Contacts}" uen:Region.Attached="true"/>
-                <ContentControl uen:Region.Name="{x:Bind constants:PageNames.WixContacts}" uen:Region.Attached="true"/>
+                <Grid uen:Region.Name="{x:Bind constants:PageNames.Contacts}">
+                    <ContentControl uen:Region.Attached="true"/>
+                </Grid>
+                <Grid uen:Region.Name="{x:Bind constants:PageNames.WixContacts}">
+                    <ContentControl uen:Region.Attached="true"/>
+                </Grid>
             </Grid>
         </NavigationView>
     </Grid>


### PR DESCRIPTION
## Summary
- Fixed an issue where both Contacts and WixContacts pages remained visible when navigating between them
- Wrapped ContentControl elements in Grid containers with proper Region names for correct visibility management
- The Region.Navigator now properly hides/shows the container Grids based on the selected navigation item

## Test plan
- [ ] Run the UnoApp
- [ ] Navigate to Main page
- [ ] Click on "Kontakte" in the navigation menu
- [ ] Verify that only the Contacts page is visible
- [ ] Click on "Wix-Kontakte" in the navigation menu  
- [ ] Verify that only the WixContacts page is visible (Contacts page should be hidden)
- [ ] Navigate back to "Kontakte" and verify proper visibility switching

🤖 Generated with [Claude Code](https://claude.ai/code)