### PR TITLE
Fix: ContentControl visibility navigation issue

### DIFF
--- a/src/UnoApp/UnoApp/Presentation/Pages/Main/MainPage.xaml
+++ b/src/UnoApp/UnoApp/Presentation/Pages/Main/MainPage.xaml
@@ -30,8 +30,12 @@
                 <Grid uen:Region.Name="One" />
                 <Grid uen:Region.Name="Two" />
                 <Grid uen:Region.Name="Three" />
-                <ContentControl uen:Region.Name="{x:Bind constants:PageNames.Contacts}" uen:Region.Attached="true"/>
-                <ContentControl uen:Region.Name="{x:Bind constants:PageNames.WixContacts}" uen:Region.Attached="true"/>
+                <Grid uen:Region.Name="{x:Bind constants:PageNames.Contacts}" Visibility="Collapsed">
+                    <ContentControl uen:Region.Attached="true"/>
+                </Grid>
+                <Grid uen:Region.Name="{x:Bind constants:PageNames.WixContacts}" Visibility="Collapsed">
+                    <ContentControl uen:Region.Attached="true"/>
+                </Grid>
             </Grid>
         </NavigationView>
     </Grid>


### PR DESCRIPTION
## Summary
- Fixed the navigation visibility issue where both Contacts and WixContacts pages remained visible when navigating between them
- The root cause was that `Region.Navigator="Visibility"` (PanelVisibilityNavigator) only works with Panel elements like Grid, not with ContentControl
- ContentControl uses ContentControlNavigator which replaces content instead of toggling visibility

## Changes
- Wrapped ContentControl elements in Grid containers with appropriate Region.Name attributes
- Added `Visibility="Collapsed"` to the Grid containers as required by PanelVisibilityNavigator
- The visibility navigator now properly hides/shows the Grid containers based on NavigationView selection

## Technical Details
The Uno Platform navigation system has different navigators:
- **PanelVisibilityNavigator**: For Panel controls (Grid, StackPanel) - toggles Visibility property
- **ContentControlNavigator**: For ContentControl - replaces Content property

By wrapping the ContentControls in Grids, we can use the visibility-based navigation as intended.

## Test Plan
- [ ] Run the UnoApp
- [ ] Navigate to Main page
- [ ] Click on "Kontakte" in the navigation menu
- [ ] Verify that only the Contacts page is visible
- [ ] Click on "Wix-Kontakte" in the navigation menu
- [ ] Verify that only the WixContacts page is visible (Contacts page should be completely hidden)
- [ ] Navigate back and forth between the pages to ensure proper visibility switching

## References
- [Uno Platform Navigation Documentation](https://platform.uno/docs/articles/external/uno.extensions/doc/Learn/Navigation/NavigationOverview.html)
- [Navigation Regions and Navigators](https://nicksnettravels.builttoroam.com/uno-extensions-navigators/)

🤖 Generated with [Claude Code](https://claude.ai/code)