### PR TITLE
Fix: Region-based navigation with single ContentControl

### DIFF
--- a/src/UnoApp/UnoApp/App.xaml.cs
+++ b/src/UnoApp/UnoApp/App.xaml.cs
@@ -101,24 +101,31 @@ public partial class App : Application
                         Nested:
                         [
                             new(
-                                PageNames.WixContacts,
-                                View: views.FindByViewModel<WixContactsPageViewModel>(),
+                                "MainContent",
+                                IsDefault: true,
                                 Nested:
                                 [
                                     new(
-                                        RegionViewsNames.WixContactList,
-                                        View: views.FindByViewModel<WixContactsListViewModel>()
+                                        PageNames.WixContacts,
+                                        View: views.FindByViewModel<WixContactsPageViewModel>(),
+                                        Nested:
+                                        [
+                                            new(
+                                                RegionViewsNames.WixContactList,
+                                                View: views.FindByViewModel<WixContactsListViewModel>()
+                                            ),
+                                        ]
                                     ),
-                                ]
-                            ),
-                            new(
-                                PageNames.Contacts,
-                                View: views.FindByViewModel<ContactsPageViewModel>(),
-                                Nested:
-                                [
                                     new(
-                                        RegionViewsNames.ContactList,
-                                        View: views.FindByViewModel<ContactsListViewModel>()
+                                        PageNames.Contacts,
+                                        View: views.FindByViewModel<ContactsPageViewModel>(),
+                                        Nested:
+                                        [
+                                            new(
+                                                RegionViewsNames.ContactList,
+                                                View: views.FindByViewModel<ContactsListViewModel>()
+                                            ),
+                                        ]
                                     ),
                                 ]
                             ),

--- a/src/UnoApp/UnoApp/Presentation/Pages/Main/MainPage.xaml
+++ b/src/UnoApp/UnoApp/Presentation/Pages/Main/MainPage.xaml
@@ -21,17 +21,32 @@
                 <NavigationViewItem Content="Three"
                                     uen:Region.Name="Three" />
                 <NavigationViewItem Content="Kontakte" 
-                                    uen:Region.Name="{x:Bind constants:PageNames.Contacts}" />
+                                    uen:Navigation.Request="./MainContent/Contacts" />
                 <NavigationViewItem Content="Wix-Kontakte" 
-                                    uen:Region.Name="{x:Bind constants:PageNames.WixContacts}" />
+                                    uen:Navigation.Request="./MainContent/WixContacts" />
             </NavigationView.MenuItems>
 
-            <Grid uen:Region.Navigator="Visibility">
-                <Grid uen:Region.Name="One" />
-                <Grid uen:Region.Name="Two" />
-                <Grid uen:Region.Name="Three" />
-                <ContentControl uen:Region.Name="{x:Bind constants:PageNames.Contacts}" uen:Region.Attached="true"/>
-                <ContentControl uen:Region.Name="{x:Bind constants:PageNames.WixContacts}" uen:Region.Attached="true"/>
+            <Grid>
+                <!-- Visibility Navigator for static content -->
+                <Grid uen:Region.Navigator="Visibility">
+                    <Grid uen:Region.Name="One">
+                        <TextBlock Text="One Content" HorizontalAlignment="Center" VerticalAlignment="Center" />
+                    </Grid>
+                    <Grid uen:Region.Name="Two">
+                        <TextBlock Text="Two Content" HorizontalAlignment="Center" VerticalAlignment="Center" />
+                    </Grid>
+                    <Grid uen:Region.Name="Three">
+                        <TextBlock Text="Three Content" HorizontalAlignment="Center" VerticalAlignment="Center" />
+                    </Grid>
+                </Grid>
+                
+                <!-- Single ContentControl for dynamic navigation -->
+                <ContentControl uen:Region.Attached="true" 
+                                uen:Region.Name="MainContent"
+                                HorizontalAlignment="Stretch"
+                                VerticalAlignment="Stretch"
+                                HorizontalContentAlignment="Stretch"
+                                VerticalContentAlignment="Stretch"/>
             </Grid>
         </NavigationView>
     </Grid>


### PR DESCRIPTION
## Summary
- Fixed the navigation visibility issue while keeping the region-based approach
- Separated static and dynamic content navigation mechanisms
- Now only one page is visible at a time

## Solution
Restructured the navigation to use:
1. **Grid with Region.Navigator="Visibility"** for static content (One, Two, Three)
2. **Single ContentControl with Region.Name="MainContent"** for dynamic pages (Contacts, WixContacts)
3. **Navigation.Request** on NavigationViewItems to navigate through the nested route

## Changes
- Updated MainPage.xaml to use a single ContentControl for dynamic navigation
- NavigationViewItems for Contacts/WixContacts now use `Navigation.Request` with nested routes:
  - `./MainContent/Contacts`
  - `./MainContent/WixContacts`
- Updated App.xaml.cs route registration to include MainContent region as a nested route container

## Technical Details
The key insight was that ContentControl uses ContentControlNavigator which replaces content rather than toggling visibility. By using a single ContentControl and navigating to different pages within it, we ensure only one page is displayed at a time.

## Test Plan
- [ ] Run the UnoApp
- [ ] Navigate to Main page
- [ ] Click on "One", "Two", "Three" - verify static content switches correctly
- [ ] Click on "Kontakte" - verify Contacts page loads in the ContentControl
- [ ] Click on "Wix-Kontakte" - verify WixContacts replaces Contacts in the ContentControl
- [ ] Navigate back and forth to ensure proper content switching
- [ ] Verify no pages remain visible when switching between items

## Benefits
- Maintains the declarative region-based navigation approach
- Properly separates static and dynamic content handling
- Works with the natural behavior of ContentControlNavigator
- Clean and maintainable solution

🤖 Generated with [Claude Code](https://claude.ai/code)