### PR TITLE
feat: Migrate database entities from int to Guid IDs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,11 @@ After completing any user request, automatically:
 - End every file with a newline.
 - Prefer file-scoped namespaces when practical.
 
+## ID Type Convention
+- **All IDs**: Always use `Guid` for both DTOs and database entities
+- **Consistency**: This ensures type safety and eliminates conversion complexity
+- **No Conversion Needed**: Direct mapping between entities and DTOs
+
 ## Shiny Mediator Usage
 - The API and UnoApp are built around the **Shiny.Mediator** pattern.
 - Shiny.Mediator uses central package management with package versions defined in `Directory.packages.props` inside the mediator src directory.

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -19,7 +19,7 @@
 
   <!-- Code Analysis and Style Enforcement -->
   <ItemGroup>
-    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
+    <PackageReference Include="StyleCop.Analyzers">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/SharedModels/Dtos/Contacts/ContactDto.cs
+++ b/src/SharedModels/Dtos/Contacts/ContactDto.cs
@@ -51,3 +51,4 @@ namespace SharedModels.Dtos.Contacts
         
         List<CallLogEntry>? CallHistory = null
     ) : BaseDto;
+}

--- a/src/WebApi/Data/Models/CallLog.cs
+++ b/src/WebApi/Data/Models/CallLog.cs
@@ -17,14 +17,14 @@ namespace WebApi.Data.Models
         /// Gets or sets the primary key identifier.
         /// </summary>
         [Key]
-        public int Id { get; set; }
+        public Guid Id { get; set; }
         
         /// <summary>
         /// Gets or sets the foreign key to the associated contact.
         /// </summary>
         [Required]
         [ForeignKey(nameof(Contact))]
-        public int ContactId { get; set; }
+        public Guid ContactId { get; set; }
         
         /// <summary>
         /// Gets or sets the navigation property to the contact.

--- a/src/WebApi/Data/Models/Contact.cs
+++ b/src/WebApi/Data/Models/Contact.cs
@@ -15,7 +15,7 @@ namespace WebApi.Data.Models
         /// Gets or sets the primary key identifier.
         /// </summary>
         [Key]
-        public int Id { get; set; }
+        public Guid Id { get; set; }
         
         /// <summary>
         /// Gets or sets the unique Wix identifier for the contact.

--- a/src/WebApi/Mediator/Handlers/Contacts/ContactsGroup.cs
+++ b/src/WebApi/Mediator/Handlers/Contacts/ContactsGroup.cs
@@ -78,12 +78,9 @@ namespace WebApi.Mediator.Handlers.Contacts
             CancellationToken ct
         )
         {
-            // TODO: Refactor to use proper ID type conversion
-            var contactId = int.TryParse(request.Id.ToString(), out var id) ? id : 0;
-            
             var contact = await db.Contacts
                 .Include(c => c.CallHistory)
-                .FirstOrDefaultAsync(c => c.Id == contactId, ct)
+                .FirstOrDefaultAsync(c => c.Id == request.Id, ct)
                 .ConfigureAwait(false);
             
             return contact != null ? MapToDto(contact) : null;
@@ -137,11 +134,8 @@ namespace WebApi.Mediator.Handlers.Contacts
             CancellationToken ct
         )
         {
-            // TODO: Refactor to use proper ID type conversion
-            var contactId = int.TryParse(request.Id.ToString(), out var id) ? id : 0;
-            
             var entity = await db.Contacts
-                .FirstOrDefaultAsync(c => c.Id == contactId, ct)
+                .FirstOrDefaultAsync(c => c.Id == request.Id, ct)
                 .ConfigureAwait(false);
                 
             if (entity != null)
@@ -312,7 +306,7 @@ namespace WebApi.Mediator.Handlers.Contacts
                 )).ToList()
             )
             {
-                Id = Guid.NewGuid(),
+                Id = contact.Id,
                 CreatedAt = contact.CreatedAt,
                 UpdatedAt = contact.UpdatedAt
             };

--- a/src/WebApi/Mediator/Requests/Contacts/RescheduleCallRequest.cs
+++ b/src/WebApi/Mediator/Requests/Contacts/RescheduleCallRequest.cs
@@ -4,7 +4,7 @@ namespace WebApi.Mediator.Requests.Contacts
 {
     internal class RescheduleCallRequest : IRequest<ContactDto>
     {
-        public int ContactId { get; set; }
+        public Guid ContactId { get; set; }
         public DateTime? NewCallDate { get; set; } // If null, use user's default days
         public string? Reason { get; set; }
     }

--- a/src/WebApi/Mediator/Requests/Contacts/UpdateCallStatusRequest.cs
+++ b/src/WebApi/Mediator/Requests/Contacts/UpdateCallStatusRequest.cs
@@ -4,7 +4,7 @@ namespace WebApi.Mediator.Requests.Contacts
 {
     internal class UpdateCallStatusRequest : IRequest<ContactDto>
     {
-        public int ContactId { get; set; }
+        public Guid ContactId { get; set; }
         public CallStatus Status { get; set; }
         public string Notes { get; set; } = "";
         public bool RescheduleCall { get; set; } = false;

--- a/src/WebApi/WebApi.json
+++ b/src/WebApi/WebApi.json
@@ -520,21 +520,38 @@
         }
       },
       "AddContactRequest": {
+        "required": [
+          "wixId",
+          "name",
+          "email",
+          "phone",
+          "industry"
+        ],
         "type": "object",
         "properties": {
           "wixId": {
+            "maxLength": 100,
+            "minLength": 0,
             "type": "string"
           },
           "name": {
+            "maxLength": 200,
+            "minLength": 0,
             "type": "string"
           },
           "email": {
+            "maxLength": 254,
+            "minLength": 0,
             "type": "string"
           },
           "phone": {
+            "maxLength": 50,
+            "minLength": 0,
             "type": "string"
           },
-          "branche": {
+          "industry": {
+            "maxLength": 100,
+            "minLength": 0,
             "type": "string"
           },
           "setInitialCallDate": {
@@ -581,7 +598,7 @@
           "name",
           "email",
           "phone",
-          "branche"
+          "industry"
         ],
         "type": "object",
         "properties": {
@@ -597,7 +614,7 @@
           "phone": {
             "type": "string"
           },
-          "branche": {
+          "industry": {
             "type": "string"
           },
           "nextCallDate": {
@@ -773,8 +790,8 @@
         "type": "object",
         "properties": {
           "contactId": {
-            "type": "integer",
-            "format": "int32"
+            "type": "string",
+            "format": "uuid"
           },
           "newCallDate": {
             "type": "string",
@@ -883,8 +900,8 @@
         "type": "object",
         "properties": {
           "contactId": {
-            "type": "integer",
-            "format": "int32"
+            "type": "string",
+            "format": "uuid"
           },
           "status": {
             "$ref": "#/components/schemas/CallStatus2"


### PR DESCRIPTION
## Summary
- Migrated all entity IDs from `int` to `Guid` for consistency
- Removed type conversion code between DTOs and entities
- Fixed StyleCop.Analyzers central package management issue

## Breaking Changes
⚠️ **This is a breaking change** - All entity IDs are now Guids instead of ints. A database migration will be required.

## Changes Made
- Changed `Contact.Id` from `int` to `Guid`
- Changed `CallLog.Id` and `ContactId` from `int` to `Guid`
- Updated `UpdateCallStatusRequest` and `RescheduleCallRequest` to use `Guid` for ContactId
- Removed ID type conversion logic from `ContactsGroup` handler
- Updated AGENTS.md documentation to reflect the new convention
- Fixed StyleCop.Analyzers version specification for central package management

## Test Plan
- [x] Build successful
- [ ] Run database migration
- [ ] Test contact CRUD operations
- [ ] Test call status updates
- [ ] Test call rescheduling

## Benefits
- **Type Safety**: Eliminates runtime type conversions
- **Consistency**: DTOs and entities now use the same ID type
- **Simplicity**: Removes conversion complexity from handlers
- **Future-proof**: Guids are better for distributed systems

🤖 Generated with [Claude Code](https://claude.ai/code)