### PR TITLE
Fix CORS error for Wix API integration - allow wix-account-id header

### DIFF
--- a/src/WebApi/Program.cs
+++ b/src/WebApi/Program.cs
@@ -28,7 +28,7 @@ namespace WebApi
                 {
                     policy.AllowAnyOrigin()
                           .AllowAnyMethod()
-                          .AllowAnyHeader();
+                          .WithHeaders("wix-account-id", "wix-site-id", "Authorization", "Content-Type", "Accept", "X-Requested-With");
                 });
             });
             


### PR DESCRIPTION
## Summary
- Update CORS policy in WebApi to explicitly allow Wix API headers
- Fix preflight error preventing UnoApp from accessing Wix Contacts API
- Replace `AllowAnyHeader()` with explicit `WithHeaders()` configuration

## Problem
The UnoApp (WebAssembly) fails to access Wix Contacts API due to CORS error:
```
Request header field wix-account-id is not allowed by Access-Control-Allow-Headers in preflight response
```

## Root Cause
While the CORS policy used `AllowAnyHeader()`, browsers are stricter with custom headers in preflight requests. The `wix-account-id` and `wix-site-id` headers from the Wix API integration need to be explicitly allowed.

## Solution
Updated `/src/WebApi/Program.cs` CORS configuration to explicitly allow:
- `wix-account-id` (required by Wix API)
- `wix-site-id` (required by Wix API) 
- `Authorization` (for API authentication)
- `Content-Type` (standard header)
- `Accept` (standard header)
- `X-Requested-With` (common for AJAX requests)

## Files Changed
- `/src/WebApi/Program.cs` - Updated CORS policy

## Test Plan
- [x] Build WebApi project successfully
- [x] Verify headers are correctly identified in WixApi integration
- [ ] Run WebApi and test UnoApp can access Wix Contacts API
- [ ] Verify no CORS preflight errors in browser console
- [ ] Test Wix Contacts page loads data successfully

## References
- Closes #70
- Related: Wix API integration in `/src/External/WixApi/ModuleInitializer.cs`

🤖 Generated with [Claude Code](https://claude.ai/code)