### PR TITLE
fix: Add Wix contacts proxy endpoint to fix CORS issues

### DIFF
--- a/src/UnoApp/UnoApp/WebApi.json
+++ b/src/UnoApp/UnoApp/WebApi.json
@@ -363,7 +363,7 @@
         "tags": [
           "WebApi"
         ],
-        "operationId": "UpdateCallSettings",
+        "operationId": "updateCallSettings",
         "requestBody": {
           "content": {
             "application/json": {
@@ -377,6 +377,38 @@
         "responses": {
           "200": {
             "description": "OK"
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "WebApi"
+        ],
+        "operationId": "getWixContacts",
+        "parameters": [
+          {
+            "name": "Limit",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/WixContactDto"
+                  }
+                }
+              }
+            }
           }
         }
       }
@@ -913,6 +945,54 @@
             "type": "boolean"
           },
           "nextCallDate": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          }
+        }
+      },
+      "WixContactDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "firstName": {
+            "type": "string",
+            "nullable": true
+          },
+          "lastName": {
+            "type": "string",
+            "nullable": true
+          },
+          "fullName": {
+            "type": "string",
+            "nullable": true
+          },
+          "email": {
+            "type": "string",
+            "nullable": true
+          },
+          "phone": {
+            "type": "string",
+            "nullable": true
+          },
+          "company": {
+            "type": "string",
+            "nullable": true
+          },
+          "labels": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "createdDate": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "updatedDate": {
             "type": "string",
             "format": "date-time",
             "nullable": true

--- a/src/WebApi/Mediator/Handlers/WixContacts/WixContactsGroup.cs
+++ b/src/WebApi/Mediator/Handlers/WixContacts/WixContactsGroup.cs
@@ -1,0 +1,34 @@
+using Microsoft.AspNetCore.Http;
+using Shiny.Mediator;
+using WebApi.Constants;
+using WebApi.Mediator.Requests.WixContacts;
+using WixApi.Repositories;
+
+namespace WebApi.Mediator.Handlers.WixContacts;
+
+[SingletonHandler]
+internal class WixContactsGroup(
+    IWixContactsRepository wixContactsRepository,
+    IHttpContextAccessor httpContextAccessor
+) : IRequestHandler<GetWixContactsRequest, List<WixContactDto>>
+{
+    [MediatorHttpGet("/WixContacts", "", RequiresAuthorization = true)]
+    public async Task<List<WixContactDto>> Handle(GetWixContactsRequest request, IMediatorContext context, CancellationToken ct)
+    {
+        var wixContacts = await wixContactsRepository.GetContactsAsync(request.Limit);
+        
+        return wixContacts.Select(x => new WixContactDto
+        {
+            Id = x.id,
+            FirstName = x.info.name?.first,
+            LastName = x.info.name?.last,
+            FullName = $"{x.info.name?.first} {x.info.name?.last}".Trim(),
+            Email = x.primaryInfo.email,
+            Phone = x.primaryInfo.phone ?? x.info.phones?.items?.FirstOrDefault()?.phone,
+            Company = x.info.company,
+            Labels = x.info.labelKeys?.items?.ToList() ?? new List<string>(),
+            CreatedDate = x.createdDate,
+            UpdatedDate = x.updatedDate
+        }).ToList();
+    }
+}

--- a/src/WebApi/Mediator/Requests/WixContacts/GetWixContactsRequest.cs
+++ b/src/WebApi/Mediator/Requests/WixContacts/GetWixContactsRequest.cs
@@ -1,0 +1,8 @@
+using Shiny.Mediator;
+
+namespace WebApi.Mediator.Requests.WixContacts;
+
+public class GetWixContactsRequest : IRequest<List<WixContactDto>>
+{
+    public int Limit { get; set; } = 20;
+}

--- a/src/WebApi/Mediator/Requests/WixContacts/WixContactDto.cs
+++ b/src/WebApi/Mediator/Requests/WixContacts/WixContactDto.cs
@@ -1,0 +1,15 @@
+namespace WebApi.Mediator.Requests.WixContacts;
+
+public class WixContactDto
+{
+    public string Id { get; set; }
+    public string? FirstName { get; set; }
+    public string? LastName { get; set; }
+    public string? FullName { get; set; }
+    public string? Email { get; set; }
+    public string? Phone { get; set; }
+    public string? Company { get; set; }
+    public List<string> Labels { get; set; } = new();
+    public DateTimeOffset? CreatedDate { get; set; }
+    public DateTimeOffset? UpdatedDate { get; set; }
+}

--- a/src/WebApi/Program.cs
+++ b/src/WebApi/Program.cs
@@ -6,6 +6,7 @@ using Scalar.AspNetCore;
 using WebApi.Data;
 using WebApi.Helpers.Authentication;
 using WebApi.Startup;
+using WixApi;
 
 namespace WebApi
 {
@@ -15,6 +16,10 @@ namespace WebApi
         {
             var builder = WebApplication.CreateBuilder(args);
             builder.Services.AddShinyMediator(x => x.AddGeneratedEndpoints());
+            
+            // Add WixApi services
+            builder.Services.AddWixApi(builder.Configuration);
+            
             // Add services to the container.
             builder.Services.AddDbContext<AppDbContext>(options =>
                 options.UseInMemoryDatabase("SalesDb")

--- a/src/WebApi/WebApi.csproj
+++ b/src/WebApi/WebApi.csproj
@@ -27,6 +27,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\SharedModels\SharedModels.csproj" />
+    <ProjectReference Include="..\External\WixApi\WixApi.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/WebApi/WebApi.json
+++ b/src/WebApi/WebApi.json
@@ -363,7 +363,7 @@
         "tags": [
           "WebApi"
         ],
-        "operationId": "api/settings/updateCallSettings",
+        "operationId": "updateCallSettings",
         "requestBody": {
           "content": {
             "application/json": {
@@ -377,6 +377,38 @@
         "responses": {
           "200": {
             "description": "OK"
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "WebApi"
+        ],
+        "operationId": "getWixContacts",
+        "parameters": [
+          {
+            "name": "Limit",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/WixContactDto"
+                  }
+                }
+              }
+            }
           }
         }
       }
@@ -913,6 +945,54 @@
             "type": "boolean"
           },
           "nextCallDate": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          }
+        }
+      },
+      "WixContactDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "firstName": {
+            "type": "string",
+            "nullable": true
+          },
+          "lastName": {
+            "type": "string",
+            "nullable": true
+          },
+          "fullName": {
+            "type": "string",
+            "nullable": true
+          },
+          "email": {
+            "type": "string",
+            "nullable": true
+          },
+          "phone": {
+            "type": "string",
+            "nullable": true
+          },
+          "company": {
+            "type": "string",
+            "nullable": true
+          },
+          "labels": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "createdDate": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "updatedDate": {
             "type": "string",
             "format": "date-time",
             "nullable": true


### PR DESCRIPTION
## Summary
- Added WixContacts proxy endpoint in WebApi to handle Wix API calls
- Fixed CORS issues preventing direct browser access to wixapis.com
- Fixed invalid operationIds in WebApi.json

## Problem
The UnoApp was trying to call Wix API directly from the browser, which resulted in CORS errors:
```
Access to fetch at 'https://www.wixapis.com/contacts/v4/contacts' 
from origin 'http://131.189.222.117:5000' has been blocked by CORS policy
```

## Solution
Created a proxy endpoint in WebApi that:
- Receives requests from UnoApp
- Makes server-side calls to Wix API (no CORS restrictions)
- Returns data to UnoApp

## Changes
- Added `WixContactsGroup` handler with `/WixContacts` endpoint
- Integrated WixApi service into WebApi
- Fixed operationIds in WebApi.json (removed forward slashes)
- Updated generated API client in UnoApp

## Test Plan
- [x] WebApi builds successfully
- [x] UnoApp builds successfully
- [x] No more CORS errors when loading Wix contacts
- [ ] Wix contacts display correctly in UnoApp

🤖 Generated with [Claude Code](https://claude.ai/code)