### PR TITLE
feat: Add /stash-update slash command

### DIFF
--- a/src/UnoApp/.claude/commands/stash-update.md
+++ b/src/UnoApp/.claude/commands/stash-update.md
@@ -1,0 +1,49 @@
+# Stash and Update Command
+
+This slash command helps you quickly stash your current changes, checkout the main branch, and pull the latest updates.
+
+## Usage
+```
+/stash-update
+```
+
+## What it does:
+1. Stashes all current changes (if any exist)
+2. Checks out the master branch
+3. Pulls the latest changes from remote
+
+## Workflow:
+
+### 1. Check for uncommitted changes
+```bash
+git status --porcelain
+```
+
+### 2. If changes exist, stash them
+```bash
+git stash push -m "Auto-stash before updating master"
+```
+
+### 3. Checkout master branch
+```bash
+git checkout master
+```
+
+### 4. Pull latest changes
+```bash
+git pull origin master
+```
+
+### 5. Show stash list (if any)
+```bash
+git stash list
+```
+
+## Options:
+- To retrieve your stashed changes later, use: `git stash pop`
+- To see what's in the stash: `git stash show -p`
+
+## Notes:
+- This command is useful when you need to quickly switch to an updated master branch
+- Your work in progress is safely stored in the stash
+- Remember to pop your stash when returning to your feature branch

--- a/src/UnoApp/CLAUDE.md
+++ b/src/UnoApp/CLAUDE.md
@@ -51,6 +51,11 @@
 - Models: `Business/Models/`
 - Services: `Business/Services/`
 
+## Slash Commands
+- `/stash-update`: Stash changes, checkout master, and pull latest
+  - See @.claude/commands/stash-update.md
+
 ## Import References
 @.claude/mvvm-patterns.md
 @.claude/navigation/regions.md
+@.claude/commands/stash-update.md


### PR DESCRIPTION
## Summary
- Added a new slash command `/stash-update` for quick workflow management
- Command stashes current changes, checks out master branch, and pulls latest updates
- Useful for developers who need to quickly sync with main branch without losing work

## Changes
- **src/UnoApp/.claude/commands/stash-update.md**: New slash command documentation
  - Detailed workflow steps
  - Usage instructions
  - Options for retrieving stashed work
- **src/UnoApp/CLAUDE.md**: 
  - Added new "Slash Commands" section
  - Referenced the stash-update command
  - Added import reference

## Benefits
- Streamlines common workflow of updating from master
- Prevents loss of work in progress
- Reduces manual git command typing
- Clear documentation of the workflow

## Usage
Simply type `/stash-update` in Claude to execute the command workflow

## Test plan
- [ ] Verify slash command loads correctly
- [ ] Test with uncommitted changes
- [ ] Test with clean working directory
- [ ] Verify stash is created when needed
- [ ] Confirm master branch is updated

🤖 Generated with [Claude Code](https://claude.ai/code)